### PR TITLE
fix regex match on python < 3.6 and cleanup dbl handling

### DIFF
--- a/game_bot.py
+++ b/game_bot.py
@@ -189,10 +189,10 @@ async def game(ctx):
                 "Please enter your search term!")
 
 #help subcommand, describes usage for !game
-@game.command()
-async def help():
+@game.command(pass_context=True)
+async def help(ctx):
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         ("Simply type **!game followed by the game "
          "you wished to be linked to** on Steam!\n\n"
 
@@ -206,10 +206,10 @@ async def help():
 
 
 #info subcommand, gives info about bot creator
-@game.command()
-async def info():
+@game.command(pass_context=True)
+async def info(ctx):
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         ("Game-Bot is written in Python, using Discord.py as an API "
          "wrapper for Discord. "
          "The bot was coded by <@156971607057760256>, a student at the "
@@ -224,20 +224,20 @@ async def info():
 
 
 #bugs subcommand, links server for bug reports
-@game.command()
-async def bugs():
+@game.command(pass_context=True)
+async def bugs(ctx):
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         ("Please join https://discord.gg/AZTP5fK with all "
          "your bugs (and to talk with me, Cool :])")
         )
 
 
 #donate subcommand, gives donation link
-@game.command()
-async def donate():
+@game.command(pass_context=True)
+async def donate(ctx):
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         ("All money goes directly to server hosting and bot development, "
           "not to me (or anyone else).")
         )

--- a/game_bot.py
+++ b/game_bot.py
@@ -116,7 +116,7 @@ async def on_ready():
 
 
 #creating game command group
-@client.group
+@client.group(pass_context=True)
 async def game(ctx):
     if ctx.invoked_subcommand is None:
         game_name = ctx.content[6:]

--- a/game_bot.py
+++ b/game_bot.py
@@ -119,7 +119,7 @@ async def on_ready():
 @client.group(pass_context=True)
 async def game(ctx):
     if ctx.invoked_subcommand is None:
-        game_name = ctx.content[6:]
+        game_name = ctx.message.content[6:]
         if game_name.lower() == "csgo" \
             or game_name.lower() == "cs" \
                 or game_name.lower() == "cs:go":

--- a/game_bot.py
+++ b/game_bot.py
@@ -126,19 +126,19 @@ async def game(ctx):
             # To bypass API shortcomings for popular games
 
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "http://store.steampowered.com/app/730")
 
         elif game_name.lower() == "pubg":
 
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "http://store.steampowered.com/app/578080")
 
         elif game_name.lower() == "n++":
 
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "http://store.steampowered.com/app/230270")
 
         elif game_name.lower() == "gta"     \
@@ -148,13 +148,13 @@ async def game(ctx):
                 or game_name.lower() == "gta v":
 
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "http://store.steampowered.com/app/271590")
 
         elif game_name.lower() == "tf2":
 
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "http://store.steampowered.com/app/440")
 
         elif len(game_name) > 0:
@@ -162,11 +162,11 @@ async def game(ctx):
                 app_id = game_search(game_name)
                 if app_id:
                     await client.send_message(
-                        message.channel,
+                        ctx.message.channel,
                         "http://store.steampowered.com/app/" + app_id)
                 else:
                     await client.send_message(
-                        message.channel,
+                        ctx.message.channel,
                         ("Please try again with less characters, "
                          "the game's full name, or with a different game.")
                         )
@@ -175,17 +175,17 @@ async def game(ctx):
                 code = e.code
                 logger.error("Got HTTPError %s" % code)
                 await client.send_message(
-                    message.channel, "Error {} returned :(".format(code)
+                    ctx.message.channel, "Error {} returned :(".format(code)
                 )
             except Exception as e:
                 logger.exception("Exception in game searching")
                 await client.send_message(
-                    message.channel, "Exception :("
+                    ctx.message.channel, "Exception :("
                 )
 
         else:
             await client.send_message(
-                message.channel,
+                ctx.message.channel,
                 "Please enter your search term!")
 
 #help subcommand, describes usage for !game
@@ -217,7 +217,7 @@ async def info(ctx):
         )
 
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         ("You can take a look at the code at:\n"
          "https://github.com/taahamahdi/Game-Bot")
         )
@@ -242,10 +242,10 @@ async def donate(ctx):
           "not to me (or anyone else).")
         )
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         "ETH: **0x8E48AD118491C571a5E22E990cea4A9d099cDEDc**")
     await client.send_message(
-        message.channel,
+        ctx.message.channel,
         "Other forms of donations coming soon!")
     
 

--- a/game_bot.py
+++ b/game_bot.py
@@ -175,7 +175,8 @@ async def game(ctx):
                 ctx.message.channel,
                 "Please enter your search term!")
 
-#help subcommand, describes usage for !game
+
+# help subcommand, describes usage for !game
 @game.command(pass_context=True)
 async def help(ctx):
     await client.send_message(
@@ -192,7 +193,7 @@ async def help(ctx):
         )
 
 
-#info subcommand, gives info about bot creator
+# info subcommand, gives info about bot creator
 @game.command(pass_context=True)
 async def info(ctx):
     await client.send_message(
@@ -210,7 +211,7 @@ async def info(ctx):
         )
 
 
-#bugs subcommand, links server for bug reports
+# bugs subcommand, links server for bug reports
 @game.command(pass_context=True)
 async def bugs(ctx):
     await client.send_message(
@@ -220,23 +221,19 @@ async def bugs(ctx):
         )
 
 
-#donate subcommand, gives donation link
+# donate subcommand, gives donation link
 @game.command(pass_context=True)
 async def donate(ctx):
     await client.send_message(
         ctx.message.channel,
         ("All money goes directly to server hosting and bot development, "
-          "not to me (or anyone else).")
-        )
+         "not to me (or anyone else)."))
     await client.send_message(
         ctx.message.channel,
         "ETH: **0x8E48AD118491C571a5E22E990cea4A9d099cDEDc**")
     await client.send_message(
         ctx.message.channel,
         "Other forms of donations coming soon!")
-    
-
-
 
 
 if __name__ == "__main__":

--- a/game_bot.py
+++ b/game_bot.py
@@ -114,63 +114,12 @@ async def on_ready():
     # End of Hugop's code
 
 
-@client.event
-async def on_message(message):
-    if message.content.startswith('!game help'):
 
-        await client.send_message(
-            message.channel,
-            ("Simply type **!game followed by the game "
-             "you wished to be linked to** on Steam!\n\n"
-
-             "Use **!game bugs** to get a link to a Discord server "
-             "where you can report bugs.\n\n"
-
-             "Use **!game donate** for an ETH address to "
-             "help pay server hosting fees.\n\n"
-             "Use **!game info** to find out more about how the bot works!")
-            )
-
-    elif message.content.startswith('!game bugs'):
-
-        await client.send_message(
-            message.channel,
-            ("Please join https://discord.gg/AZTP5fK with all "
-             "your bugs (and to talk with me, Cool :])")
-            )
-
-    elif message.content.startswith('!game donate'):
-
-        await client.send_message(
-            message.channel,
-            ("All money goes directly to server hosting and bot development, "
-             "not to me (or anyone else).")
-            )
-        await client.send_message(
-            message.channel,
-            "ETH: **0x8E48AD118491C571a5E22E990cea4A9d099cDEDc**")
-        await client.send_message(
-            message.channel,
-            "Other forms of donations coming soon!")
-
-    elif message.content.startswith('!game info'):
-
-        await client.send_message(
-            message.channel,
-            ("Game-Bot is written in Python, using Discord.py as an API "
-             "wrapper for Discord. "
-             "The bot was coded by <@156971607057760256>, a student at the "
-             "University of Waterloo in Canada.")
-            )
-
-        await client.send_message(
-            message.channel,
-            ("You can take a look at the code at:\n"
-             "https://github.com/taahamahdi/Game-Bot")
-            )
-
-    elif message.content.startswith('!game'):  # When !game is entered in chat
-        game_name = message.content[6:]
+#creating game command group
+@client.group
+async def game(ctx):
+    if ctx.invoked_subcommand is None:
+        game_name = ctx.content[6:]
         if game_name.lower() == "csgo" \
             or game_name.lower() == "cs" \
                 or game_name.lower() == "cs:go":
@@ -238,6 +187,69 @@ async def on_message(message):
             await client.send_message(
                 message.channel,
                 "Please enter your search term!")
+
+#help subcommand, describes usage for !game
+@game.command()
+async def help():
+    await client.send_message(
+        message.channel,
+        ("Simply type **!game followed by the game "
+         "you wished to be linked to** on Steam!\n\n"
+
+         "Use **!game bugs** to get a link to a Discord server "
+         "where you can report bugs.\n\n"
+
+         "Use **!game donate** for an ETH address to "
+         "help pay server hosting fees.\n\n"
+         "Use **!game info** to find out more about how the bot works!")
+        )
+
+
+#info subcommand, gives info about bot creator
+@game.command()
+async def info():
+    await client.send_message(
+        message.channel,
+        ("Game-Bot is written in Python, using Discord.py as an API "
+         "wrapper for Discord. "
+         "The bot was coded by <@156971607057760256>, a student at the "
+         "University of Waterloo in Canada.")
+        )
+
+    await client.send_message(
+        message.channel,
+        ("You can take a look at the code at:\n"
+         "https://github.com/taahamahdi/Game-Bot")
+        )
+
+
+#bugs subcommand, links server for bug reports
+@game.command()
+async def bugs():
+    await client.send_message(
+        message.channel,
+        ("Please join https://discord.gg/AZTP5fK with all "
+         "your bugs (and to talk with me, Cool :])")
+        )
+
+
+#donate subcommand, gives donation link
+@game.command()
+async def donate():
+    await client.send_message(
+        message.channel,
+        ("All money goes directly to server hosting and bot development, "
+          "not to me (or anyone else).")
+        )
+    await client.send_message(
+        message.channel,
+        "ETH: **0x8E48AD118491C571a5E22E990cea4A9d099cDEDc**")
+    await client.send_message(
+        message.channel,
+        "Other forms of donations coming soon!")
+    
+
+
 
 
 if __name__ == "__main__":

--- a/game_bot.py
+++ b/game_bot.py
@@ -6,6 +6,7 @@ import urllib.request
 import urllib.parse
 import aiohttp
 
+from discord.ext.commands import Bot
 from lxml import html
 
 
@@ -22,7 +23,7 @@ from lxml import html
 base_url = "http://store.steampowered.com/search/suggest"
 appid_regex = re.compile("steam/apps/([0-9]+)/")
 
-client = discord.Client()  # Creating bot instance
+client = Bot(command_prefix='!')  # Creating bot instance
 
 logger = logging.getLogger('game_bot')
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- `__getitem__` for regex matching was only added in python 3.6, so we use
the old way for backwards compat
- Minimize the amount of code that's run as part of the module so that the
tests can still run
- use client.user.id because client.bot.id doesn't exist

Also includes #2 