### PR TITLE
Refrain from changing presence in `on_ready`

### DIFF
--- a/game_bot.py
+++ b/game_bot.py
@@ -32,7 +32,7 @@ from embed import game_message
 # [Optional] Set your Bot token directly through the code
 # os.environ["GAME_BOT_TOKEN"] = "TOKEN"
 
-client = Bot(command_prefix='!')  # Creating bot instance
+client = Bot(command_prefix='!', activity= discord.Game(name='!game help'))  # Creating bot instance
 
 # Prevents bot from responding to !help calls
 client.remove_command('help')
@@ -56,7 +56,6 @@ async def on_ready():
     print(client.user.id)
     print("Guild count: %s" % len(client.guilds))
     print("------")
-    await client.change_presence(activity=discord.Game(name='!game help'))
     dbl_tracker.setup(client)
 
 


### PR DESCRIPTION
Discord has a high chance to completely disconnect during the READY or GUILD_CREATE events (1006 close code) and there is nothing to do to prevent it. 
As noted in the docs, `on_ready` is also triggered multiple times, not just once.
Therefore it is highly inadvisable to change presence in `on_ready`.
This PR fixes that and puts `activity=` in client constructor instead.